### PR TITLE
Replacement of the output_ref.mp4 file

### DIFF
--- a/examples/archive-stitcher/.gitattributes
+++ b/examples/archive-stitcher/.gitattributes
@@ -1,0 +1,1 @@
+*.mp4 filter=lfs diff=lfs merge=lfs -text

--- a/examples/archive-stitcher/test_data/screenshare_low_variation/output_ref.mp4
+++ b/examples/archive-stitcher/test_data/screenshare_low_variation/output_ref.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:71c11b29927cc3718865351ca63cc949a2e13036cd43ac5f0df450cd9e7e742b
-size 58631395
+oid sha256:a29e088fa3a86e8fb1a2b9913b2926ec0d06d99e4a8e5e1bcf70cf78628072e3
+size 58699150


### PR DESCRIPTION
Replacement of the output_ref.mp4 file. Now, instead of it being the reconstructed video, it is the original video.