### PR TITLE
[VIDMP-1275]: Remove warning messages and implement Pearson correlation formula (Option 2)

### DIFF
--- a/examples/archive-stitcher/src/overlap.py
+++ b/examples/archive-stitcher/src/overlap.py
@@ -160,20 +160,22 @@ def release_video(video: cv2.VideoCapture):
 
 
 def compute_audio_score(window_a: np.ndarray, window_b: np.ndarray, conf: FindOverlapArgs) -> tuple[float, float]:
+    # Both windows have 12 rows with equal or approximately win_frames columns, i.e, (12 rows, win_frames columns)
     match conf.algo_audio:
         case conf.algo_audio.PEARSON:
+            # axis=1: <signal>.shape[1] values for each row in <signal>.shape[0].
             a_centered = window_a - window_a.mean(axis=1, keepdims=True)
             b_centered = window_b - window_b.mean(axis=1, keepdims=True)
 
-            # Compute the numerator: dot product along rows
+            # Compute the numerator: sum accros columns for each row
             numerator = np.sum(a_centered * b_centered, axis=1)
-
-            # Compute the denominator: product of L2 norms along rows
-            a_norm = np.linalg.norm(a_centered, axis=1)
-            b_norm = np.linalg.norm(b_centered, axis=1)
-            denominator = a_norm * b_norm
+            # Compute the denominator
+            denominator = np.sqrt(np.sum(a_centered**2, axis=1) * np.sum(b_centered**2, axis=1))
 
             correlations = numerator / (denominator + ACCEPTED_ERROR)
+
+            # Pearson chromas values are constrained to the range [-1, +1].
+            # Therefore, np.nanstd(pearson_chromas) is constrained to the range [0, 1]
             # Similarity values closer to 1 have high similarity
             similarity: np.float32 = 1 - min(np.nanstd(correlations) / 0.5, 1.0)
 


### PR DESCRIPTION
For example, the Pearson correlation definition is given by: https://online.stat.psu.edu/stat501/lesson/1/1.6 or https://www.sciencedirect.com/topics/computer-science/pearson-correlation

<img width="679" height="385" alt="pearson_correlation_eq" src="https://github.com/user-attachments/assets/fe36e295-3d0e-4bbd-a260-3c1d10a81d6c" />

https://numpy.org/doc/2.3/reference/generated/numpy.linalg.norm.html

<img width="724" height="669" alt="Screenshot 2025-09-03 at 15 39 38" src="https://github.com/user-attachments/assets/cf0e5b6a-790a-4fd6-b6a9-6b56bcb77bc2" />

https://jira.vonage.com/browse/VIDMP-1275
