### PR TITLE
[VIDMP-1279]: Change the audio similarity analysis window size to match a fixed amount of time in the temporal domain

### DIFF
--- a/examples/archive-stitcher/src/overlap.py
+++ b/examples/archive-stitcher/src/overlap.py
@@ -322,7 +322,7 @@ def compute_overlapping_cqt(y_a: np.ndarray, y_b: np.ndarray, rate: int,
     chroma_a: np.ndarray = librosa.feature.chroma_cqt(y=y_a, sr=rate, hop_length=HOP_LENGTH)
     chroma_b: np.ndarray = librosa.feature.chroma_cqt(y=y_b, sr=rate, hop_length=HOP_LENGTH)
 
-    # window that covers WINDOW_NUM_SECS seconds
+    # The win_frames sliding window approximately covers WINDOW_NUM_SECS amount of time in the time domain
     win_frames: int = int(WINDOW_NUM_SECS * np.ceil(conf.audio_desc.sample_rate/HOP_LENGTH))
 
     if not conf.deep_search:


### PR DESCRIPTION
https://jira.vonage.com/browse/VIDMP-1279

It's blocked by https://github.com/opentok/archive-post-processing/pull/15

Some concepts that need to be considered when talking about time-frequency domains:
1. Time step concept
Temporal domain                                 ||              Samples Frequential domain Frames
1/sr seconds (num_samples/sr)         ||      hop_length/sr seconds (num_frames * hop_length)/sr

2. Samples, seconds and frames numbers:
sample_rate/hop_length=num_chroma_samples_per_second
e.g., 48000/512=93.75 number of samples per second in the frequency domain (CQT)
num_samples = frames * hop_length
time = sample / sr (float in seconds)

3. Library method convertors:
Librosa.frames_to_samples(frames, hop_length=512):
samples[i] = frames[i] * hop_length
Librosa.frames_to_time(frames, sr=22050, hop_length=512):
times[i] = frames[i] * (hop_length / sr)
Librosa.samples_to_frames(samples, hop_length=512):
frames[i] = floor( samples[i] / hop_length )
Librosa.time_to_frames(times, sr=22050, hop_length=512):
frames[i] = floor( times[i] * sr / hop_length )

