### PR TITLE
feat(ArchiveStitcher) [CHERRY] [VIDMP-1347]: Add HOP_LENGTH constant definition

### DIFF
--- a/examples/archive-stitcher/src/overlap.py
+++ b/examples/archive-stitcher/src/overlap.py
@@ -28,6 +28,8 @@ RESIZE_FACTOR: Final[np.float32] = 0.5
 # Accepted error to avoid the indetermination: anyValue/0
 ACCEPTED_ERROR: Final[np.float32] = 1e-8
 
+# The number of samples between successive frames (librosa default value)
+HOP_LENGTH: Final[int] = 512
 
 @dataclass(eq=True)
 class SimilarityEntry:
@@ -316,8 +318,8 @@ def compute_overlapping_cqt(y_a: np.ndarray, y_b: np.ndarray, rate: int,
     num_audio_windows: Final[int] = 5
 
     # Compute 12 chroma features (pitch classes) from Constant-Q Transform
-    chroma_a: np.ndarray = librosa.feature.chroma_cqt(y=y_a, sr=rate)
-    chroma_b: np.ndarray = librosa.feature.chroma_cqt(y=y_b, sr=rate)
+    chroma_a: np.ndarray = librosa.feature.chroma_cqt(y=y_a, sr=rate, hop_length=HOP_LENGTH)
+    chroma_b: np.ndarray = librosa.feature.chroma_cqt(y=y_b, sr=rate, hop_length=HOP_LENGTH)
 
     win_frames: int = int(min(chroma_a.shape[1], chroma_b.shape[1]) / num_audio_windows)
 
@@ -348,10 +350,10 @@ def find_overlap_audio(archive_a: Path, archive_b: Path, conf: FindOverlapArgs) 
     if (overlap_indeces_a.end == 0 or overlap_indeces_b.end == 0):
         return OverlapInterval()  # pragma: no cover
 
-    start_time_a = librosa.frames_to_time(overlap_indeces_a.ini, sr=rate)
-    start_time_b = librosa.frames_to_time(overlap_indeces_b.ini, sr=rate)
-    end_time_a = librosa.frames_to_time(overlap_indeces_a.end, sr=rate)
-    end_time_b = librosa.frames_to_time(overlap_indeces_b.end, sr=rate)
+    start_time_a = librosa.frames_to_time(overlap_indeces_a.ini, sr=rate, hop_length=HOP_LENGTH)
+    start_time_b = librosa.frames_to_time(overlap_indeces_b.ini, sr=rate, hop_length=HOP_LENGTH)
+    end_time_a = librosa.frames_to_time(overlap_indeces_a.end, sr=rate, hop_length=HOP_LENGTH)
+    end_time_b = librosa.frames_to_time(overlap_indeces_b.end, sr=rate, hop_length=HOP_LENGTH)
 
     if conf.debug_plot:
         print(f"Best alignment for audio_a starts at sec: {(start_time_a + offset_a.total_seconds()):.2f}s")


### PR DESCRIPTION
https://jira.vonage.com/browse/VIDMP-1347

Librosa uses by default a hop_length (number of samples between successive CQT columns) value of 512 samples. This value can be changed. If so, the code needs to be consistent. Due to this, this PR declares a constant HOP_LENGTH value and propagate it along the code.